### PR TITLE
Fix: Added Packer AMI automation and CloudFormation update

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build-server": "tsc -p src/server/tsconfig-server.json",
     "run-server-ec2": "node serverDist/server.js",
     "run-server-local" : "node dist/serverDist/server.js",
-    "deploy": "aws cloudformation create-stack --region us-east-2 --stack-name testprogram5 --template-body file://./src/scripts/cloudFormationDeploy.yaml --capabilities CAPABILITY_IAM"
+    "deploy": "aws cloudformation create-stack --region us-east-2 --stack-name testprogram806 --template-body file://./src/scripts/cloudFormationDeploy.yaml --capabilities CAPABILITY_IAM",
+    "packer": "packer build src/scripts/packer/aws-ubuntu.pkr.hcl"
   },
   "dependencies": {
     "@aws-sdk/client-cloudwatch-logs": "^3.465.0",

--- a/src/scripts/cloudFormationDeploy.yaml
+++ b/src/scripts/cloudFormationDeploy.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: EC2LambdaTestDeploy1
+Description: EC2LambdaTestDeploy102
 
 Resources:
   MySecurityGroup:
@@ -50,16 +50,17 @@ Resources:
     Properties:
       InstanceType: t2.micro
       IamInstanceProfile: !Ref EC2InstanceProfile
-      ImageId: ami-04af221020bbd0872
+      ImageId:  ami-039f5d5f278d91a6f
       SecurityGroupIds:
         - !Ref MySecurityGroup
-      UserData: !Base64 
-        'Fn::Sub': >
+      UserData: !Base64 |
           #!/bin/bash
-          cd /home/ubuntu/dist
+          su - ubuntu -c "sudo -i -u ubuntu"
+          su - ubuntu -c "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.4/install.sh | bash"
+          su - ubuntu -c "source ~/.nvm/nvm.sh && nvm install --lts"     
+          cd /home/ubuntu/dist     
           su - ubuntu -c "source ~/.nvm/nvm.sh && cd ~/dist && npm install"
-          su - ubuntu -c "source ~/.nvm/nvm.sh && cd ~/dist && npm run
-          run-server-ec2"
+          su - ubuntu -c "source ~/.nvm/nvm.sh && cd ~/dist && npm run run-server-ec2"
       Tags:
         - Key: EC2LambdaTestDeploy
           Value: MyTag

--- a/src/scripts/packer/aws-ubuntu.pkr.hcl
+++ b/src/scripts/packer/aws-ubuntu.pkr.hcl
@@ -1,0 +1,37 @@
+packer {
+  required_plugins {
+    amazon = {
+      version = ">= 1.2.8"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+source "amazon-ebs" "ubuntu" {
+  ami_name      = "shear-v4"
+  ami_groups    = ["all"]
+  instance_type = "t2.micro"
+  region        = "us-east-2"
+  source_ami_filter {
+    filters = {
+      name                = "ubuntu/images/*ubuntu-jammy-22.04-amd64-server-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["099720109477"]
+  }
+  ssh_username = "ubuntu"
+}
+
+build {
+  name = "packerv1"
+  sources = [
+    "source.amazon-ebs.ubuntu"
+  ]
+
+  provisioner "file" {
+    source      = "/Users/alby/Desktop/shear/dist"
+    destination = "/home/ubuntu/"
+  }
+}


### PR DESCRIPTION
**Background:**
Manually updating AMI after each push is tedious, so implemented HC Packer to reduce some clicking. Also updated CloudFormation UserData init script. 

**Instructions**
Assuming you have a build ready, there are currently two major steps to deploy (with small steps in between the two steps).

Step 1: “npm run packer”
- Install packer (https://developer.hashicorp.com/packer/tutorials/aws-get-started/get-started-install-cli)
- In aws-ubuntu.pkr.hcl change the source (build object, provisioner file) to match absolute path of dist folder
- Change ami_name to something unique if you’ve used this file before (change each time)
- run "packer init ." (If this is your first time using this HCL file)
- Export AWS credentials in CLI
    - export AWS_ACCESS_KEY_ID="<YOUR_AWS_ACCESS_KEY_ID>"
    - export AWS_SECRET_ACCESS_KEY="<YOUR_AWS_SECRET_ACCESS_KEY>"
- Run command “npm run packer”
- Output of this command should be AMI image ID, save this for step 2

Step 2: “npm run deploy”
- Inside cloudFormationDeploy.yaml, update ImageId field with new AMI produced from prev step
- Inside of package.json, under the deploy command, make sure that name after “—stack-name” is something you haven’t used before. This will need to be changed each time you deploy a CF stack.
- Run command “npm run deploy”
- After stack has completed, wait for 1 min or 2 before accessing link 

**Expected Behavior**
After all steps are completed, go to EC2 IPv4 address add port 3000 to the end and remove the “s” from “http” (e.g.  http://ec2-3-144-128-131.us-east-2.compute.amazonaws.com:3000/ )

**Next Steps**
Currently, there is some manual work in between- pasting updated AMI, changing stack name on CloudFormation, etc. Going to explore some changes to automate the whole process so all you need is one command 🙂